### PR TITLE
Clean up `CommentHeader::commit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "zoog"
-version = "0.3.0"
+version = "0.3.1-develop"
 dependencies = [
  "audiopus_sys",
  "bs1770",

--- a/src/comment_header.rs
+++ b/src/comment_header.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Write};
+use std::io::{Cursor, Read};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use derivative::Derivative;
@@ -152,18 +152,18 @@ impl<'a> CommentHeader<'a> {
     fn commit(&mut self) {
         let data = &mut self.data;
         data.clear();
-        data.write_all(COMMENT_MAGIC).unwrap();
+        data.extend(COMMENT_MAGIC);
         let vendor = self.vendor.as_bytes();
         data.write_u32::<LittleEndian>(vendor.len() as u32).unwrap();
-        data.write_all(vendor).unwrap();
+        data.extend(vendor);
         data.write_u32::<LittleEndian>(self.user_comments.len() as u32).unwrap();
-        let equals: &[u8] = &[0x3d];
+        let equals: u8 = 0x3d;
         for (k, v) in self.user_comments.iter().map(|(k, v)| (k.as_bytes(), v.as_bytes())) {
             let len = k.len() + v.len() + 1;
             data.write_u32::<LittleEndian>(len as u32).unwrap();
-            data.write_all(k).unwrap();
-            data.write_all(equals).unwrap();
-            data.write_all(v).unwrap();
+            data.extend(k);
+            data.push(equals);
+            data.extend(v);
         }
     }
 }

--- a/src/comment_header.rs
+++ b/src/comment_header.rs
@@ -150,22 +150,21 @@ impl<'a> CommentHeader<'a> {
     }
 
     fn commit(&mut self) {
-        //TODO: Look more into why we can't use https://github.com/rust-lang/rust/pull/46830
-        let mut writer = Cursor::new(Vec::new());
-        writer.write_all(COMMENT_MAGIC).unwrap();
+        let data = &mut self.data;
+        data.clear();
+        data.write_all(COMMENT_MAGIC).unwrap();
         let vendor = self.vendor.as_bytes();
-        writer.write_u32::<LittleEndian>(vendor.len() as u32).unwrap();
-        writer.write_all(vendor).unwrap();
-        writer.write_u32::<LittleEndian>(self.user_comments.len() as u32).unwrap();
+        data.write_u32::<LittleEndian>(vendor.len() as u32).unwrap();
+        data.write_all(vendor).unwrap();
+        data.write_u32::<LittleEndian>(self.user_comments.len() as u32).unwrap();
         let equals: &[u8] = &[0x3d];
         for (k, v) in self.user_comments.iter().map(|(k, v)| (k.as_bytes(), v.as_bytes())) {
             let len = k.len() + v.len() + 1;
-            writer.write_u32::<LittleEndian>(len as u32).unwrap();
-            writer.write_all(k).unwrap();
-            writer.write_all(equals).unwrap();
-            writer.write_all(v).unwrap();
+            data.write_u32::<LittleEndian>(len as u32).unwrap();
+            data.write_all(k).unwrap();
+            data.write_all(equals).unwrap();
+            data.write_all(v).unwrap();
         }
-        *self.data = writer.into_inner();
     }
 }
 

--- a/src/volume_analyzer.rs
+++ b/src/volume_analyzer.rs
@@ -203,8 +203,8 @@ impl VolumeAnalyzer {
     /// analyzer
     pub fn last_track_lufs(&self) -> Option<Decibels> { self.track_loudness.last().cloned() }
 
-    /// Returns the mean LUFS of all completed files submitted to the supplied volume
-    /// analyzers
+    /// Returns the mean LUFS of all completed files submitted to the supplied
+    /// volume analyzers
     pub fn mean_lufs_across_multiple<'a, I: IntoIterator<Item = &'a VolumeAnalyzer>>(analyzers: I) -> Decibels {
         let mut windows: Vec<Power> = Vec::new();
         for analyzer in analyzers.into_iter() {


### PR DESCRIPTION
* Write directly to `Vec` instead of constructing a `Cursor`.
* Use `extend()` over `write_all()` where possible to avoid `unwrap()`.