### PR TITLE
Fix/improve comment field name handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Document `VolumeAnalyzer::mean_lufs_across_multiple()`.
 * Deliberately panic on some exceptional Opus comment cases.
 * Treat Opus comment keys case-insensitively and add tests (bugfix).
+* Improve Opus comment field name validation.
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Minor code cleanup.
 * Document `VolumeAnalyzer::mean_lufs_across_multiple()`.
 * Deliberately panic on some exceptional Opus comment cases.
+* Treat Opus comment keys case-insensitively and add tests (bugfix).
 
 ## 0.3.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.11"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed45cc2c62a3eff523e718d8576ba762c83a3146151093283ac62ae11933a73"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.10"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db342ce9fda24fb191e2ed4e102055a4d381c1086a06630174cd8da8d5d917ce"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -232,9 +232,9 @@ checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -635,7 +635,7 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "zoog"
-version = "0.3.1-develop"
+version = "0.4.0-develop"
 dependencies = [
  "audiopus_sys",
  "bs1770",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zoog"
-version = "0.3.1-develop"
+version = "0.4.0-develop"
 authors = ["Francis Russell <francis@unchartedbackwaters.co.uk>"]
 edition = "2018"
 homepage = "https://github.com/FrancisRussell/zoog"

--- a/src/comment_header.rs
+++ b/src/comment_header.rs
@@ -153,6 +153,11 @@ impl<'a> CommentHeader<'a> {
         Ok(())
     }
 
+    /// Returns the number of user comments in the header
+    pub fn len(&self) -> usize {
+        self.user_comments.len()
+    }
+
     fn commit(&mut self) -> Result<(), CommitError> {
         let data = &mut self.data;
         data.clear();
@@ -313,6 +318,52 @@ mod tests {
         header_2.append("v3", "k3");
         header_2.append("v5", "k5");
         header_2.append("v7", "k7");
+
+        assert_eq!(header_1, header_2);
+    }
+
+    #[test]
+    fn get_first_case_insensitive() {
+        let mut data_1 = Vec::new();
+        let mut header_1 = CommentHeader::empty(&mut data_1);
+        header_1.append("FooBar", "1");
+        header_1.append("FOOBAR", "2");
+        header_1.append("foobar", "3");
+
+        assert_eq!(header_1.get_first("FooBar"), Some("1"));
+        assert_eq!(header_1.get_first("FOOBAR"), Some("1"));
+        assert_eq!(header_1.get_first("foobar"), Some("1"));
+        assert_eq!(header_1.get_first("FoObAr"), Some("1"));
+    }
+
+    #[test]
+    fn replace_case_insensitive() {
+        let mut data_1 = Vec::new();
+        let mut header_1 = CommentHeader::empty(&mut data_1);
+        header_1.append("FooBar", "1");
+        header_1.append("FOOBAR", "2");
+        header_1.append("foobar", "3");
+        header_1.replace("FoObAr", "42");
+
+        assert_eq!(header_1.get_first("FOObar"), Some("42"));
+        assert_eq!(header_1.len(), 1);
+    }
+
+    #[test]
+    fn remove_all_case_insensitive() {
+        let mut data_1 = Vec::new();
+        let mut header_1 = CommentHeader::empty(&mut data_1);
+        header_1.append("FooBar", "1");
+        header_1.append("FOOBAR", "2");
+        header_1.append("v0", "k0");
+        header_1.append("foobar", "3");
+        header_1.append("v5", "k5");
+        header_1.remove_all("FOObar");
+
+        let mut data_2 = Vec::new();
+        let mut header_2 = CommentHeader::empty(&mut data_2);
+        header_2.append("v0", "k0");
+        header_2.append("v5", "k5");
 
         assert_eq!(header_1, header_2);
     }

--- a/src/comment_header.rs
+++ b/src/comment_header.rs
@@ -41,8 +41,7 @@ impl<'a> CommentHeader<'a> {
     fn validate_field_name(field_name: &str) -> Result<(), Error> {
         for c in field_name.chars() {
             match c {
-                '=' => return Err(Error::InvalidOpusCommentFieldName(field_name.into())),
-                '\u{20}'..='\u{7D}' => {}
+                ' '..='<' | '>'..='}' => {}
                 _ => return Err(Error::InvalidOpusCommentFieldName(field_name.into())),
             }
         }

--- a/src/comment_header.rs
+++ b/src/comment_header.rs
@@ -36,6 +36,8 @@ impl<'a> CommentHeader<'a> {
         reader.read_exact(data).map_err(|_| Error::MalformedCommentHeader)
     }
 
+    fn keys_equal(k1: &str, k2: &str) -> bool { k1.eq_ignore_ascii_case(k2) }
+
     /// Constructs an empty `CommentHeader`. The comment data will be placed in
     /// the supplied `Vec`. Any existing content will be discarded.
     pub fn empty(data: &'a mut Vec<u8>) -> CommentHeader<'a> {
@@ -78,11 +80,11 @@ impl<'a> CommentHeader<'a> {
 
     /// Returns the first mapped value for the specified key.
     pub fn get_first(&self, key: &str) -> Option<&str> {
-        self.user_comments.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
+        self.user_comments.iter().find(|(k, _)| Self::keys_equal(k, key)).map(|(_, v)| v.as_str())
     }
 
     /// Removes all mappings for the specified key.
-    pub fn remove_all(&mut self, key: &str) { self.user_comments.retain(|(k, _)| key != k); }
+    pub fn remove_all(&mut self, key: &str) { self.user_comments.retain(|(k, _)| !Self::keys_equal(key, k)); }
 
     /// If the key already exists, update the first mapping's value to the one
     /// supplied and discard any later mappings. If the key does not exist,
@@ -90,7 +92,7 @@ impl<'a> CommentHeader<'a> {
     pub fn replace(&mut self, key: &str, value: &str) {
         let mut found = false;
         self.user_comments.retain_mut(|(k, ref mut v)| {
-            if k == key {
+            if Self::keys_equal(k, key) {
                 if found {
                     // If we have already found the key, discard this mapping
                     false

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,4 +82,8 @@ pub enum Error {
     /// A path did not have a final named component
     #[error("The path `{0}` did not have a final named component")]
     NotAFilePath(PathBuf),
+
+    /// Invalid Opus comment field name
+    #[error("Invalid Opus comment field name: `{0}`")]
+    InvalidOpusCommentFieldName(String),
 }

--- a/src/rewriter.rs
+++ b/src/rewriter.rs
@@ -186,7 +186,7 @@ impl<W: Write> Rewriter<'_, W> {
                     opus_header.set_output_gain(new_header_gain);
                     for (tag, gain) in [(TAG_TRACK_GAIN, track_gain_r128), (TAG_ALBUM_GAIN, album_gain_r128)] {
                         if let Some(gain) = gain {
-                            comment_header.replace(tag, &format!("{}", gain.as_fixed_point()));
+                            comment_header.replace(tag, &format!("{}", gain.as_fixed_point()))?;
                         } else {
                             comment_header.remove_all(tag);
                         }


### PR DESCRIPTION
* Treat comment field names case insensitively.
* Add tests for case-insensitive field name handling.
* Validate that field names are the specified ASCII subset.
* Bump version due to API change.